### PR TITLE
Prevent debug messages from flooding the dbus logs

### DIFF
--- a/daemon/main.py
+++ b/daemon/main.py
@@ -28,7 +28,7 @@ import lyricsource
 from osdlyrics.metadata import Metadata
 from osdlyrics.consts import MPRIS2_OBJECT_PATH
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.WARNING)
 
 class InvalidClientNameException(Exception):
     """ The client bus name in Hello is invalid
@@ -64,7 +64,7 @@ class MainApp(osdlyrics.App):
         try:
             self.connection.activate_name_owner(osdlyrics.CONFIG_BUS_NAME)
         except:
-            print "Cannot activate config service"
+            logging.error("Cannot activate config service")
 
     def _player_properties_changed(self, iface, changed, invalidated):
         if 'Metadata' in changed:

--- a/players/http/http.py
+++ b/players/http/http.py
@@ -18,6 +18,7 @@
 # along with OSD Lyrics.  If not, see <http://www.gnu.org/licenses/>. 
 #/
 
+import logging
 import glib
 import server
 import datetime
@@ -42,7 +43,7 @@ class HttpPlayerProxy(BasePlayerProxy):
         self._player_counter = 1
         
     def _handle_req(self, fd, event):
-        print 'new request %s, %s' % (fd, event)
+        logging.debug('new request %s, %s', fd, event)
         self._server.handle_request()
         return True
 
@@ -102,7 +103,7 @@ class HttpPlayer(BasePlayer):
         now = datetime.datetime.now()
         duration = now - self._last_ping
         if duration.total_seconds() * 1000 > CONNECTION_TIMEOUT * 2:
-            print '%s connection timeout' % self.name
+            logging.warning('%s connection timeout', self.name)
             self.disconnect()
 
     def disconnect(self):

--- a/players/http/server.py
+++ b/players/http/server.py
@@ -99,7 +99,7 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                       'caps': PARAM_CAPS,
                       })
     def do_connect(self, params):
-        print 'caps: %s' % params['caps']
+        logging.debug('caps: %s', params['caps'])
         return json.dumps({'id': self.server.player_proxy.add_player(params['name'],
                                                                      params['caps']),
                            })
@@ -152,7 +152,6 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         try:
             return self.server.player_proxy.get_player(name)
         except Exception, e:
-            print e
             raise BadRequestError('Invalid player id: %s' % name)
         
 

--- a/players/mpd/mpd_proxy.py
+++ b/players/mpd/mpd_proxy.py
@@ -40,13 +40,11 @@ from osdlyrics.utils import cmd_exists
 
 if not hasattr(mpd.MPDClient(), 'send_idle'):
     logging.error('Require python-mpd >= 0.3')
-    exit
+    exit(1)
 
 PLAYER_NAME = 'Mpd'
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 6600
-
-logging.root.setLevel(logging.DEBUG)
 
 class NoConnectionError(Exception):
     pass
@@ -322,7 +320,7 @@ class MpdPlayer(BasePlayer):
             self.proxy.send_command(cmd, handler, *args)
 
     def _handle_status(self, status):
-        print 'status\n%s' % status
+        logging.debug('status\n%s', status)
         changes = set()
         for prop, handler in self.STATUS_CHANGE_MAP.items():
             if not prop in status:
@@ -397,8 +395,8 @@ class MpdPlayer(BasePlayer):
             if change in self.CHANGE_CMDS:
                 for cmd in self.CHANGE_CMDS[change]:
                     cmds.add(cmd)
-        print 'changes: %s' % changes
-        print 'cmds: %s' % cmds
+        logging.debug('changes: %s', changes)
+        logging.debug('cmds: %s', cmds)
         for cmd in cmds:
             self._send_cmd(cmd)
 

--- a/players/mpris1/mpris1.py
+++ b/players/mpris1/mpris1.py
@@ -18,6 +18,7 @@
 # along with OSD Lyrics.  If not, see <http://www.gnu.org/licenses/>. 
 #/
 
+import logging
 import dbus
 import osdlyrics
 
@@ -94,7 +95,7 @@ class Mpris1Player(BasePlayer):
             self._name_watch = self.connection.watch_name_owner(mpris1_service_name,
                                                                 self._name_lost)
         except Exception, e:
-            print 'Fail to connect to mpris1 player %s: %s' % (player_name, e)
+            logging.error('Fail to connect to mpris1 player %s: %s', player_name, e)
             self.disconnect()
 
     def _name_lost(self, name):
@@ -154,7 +155,7 @@ class Mpris1Player(BasePlayer):
 
     def get_metadata(self):
         mt = self._player.GetMetadata()
-        print mt
+        logging.debug(repr(mt))
         return Metadata.from_dict(mt)
 
     def get_caps(self):

--- a/python/dbusext/service.py
+++ b/python/dbusext/service.py
@@ -18,6 +18,7 @@
 # along with OSD Lyrics.  If not, see <http://www.gnu.org/licenses/>. 
 #/
 
+import logging
 import dbus
 import dbus.exceptions
 import dbus.service
@@ -175,7 +176,7 @@ class Object(ObjectType):
     @dbus.service.signal(dbus_interface=dbus.PROPERTIES_IFACE,
                          signature='sa{sv}as')
     def PropertiesChanged(self, iface_name, changed_props, invalidated_props):
-        print '%s changed: %s invalidated: %s' % (iface_name, changed_props, invalidated_props)
+        logging.debug('%s changed: %s invalidated: %s', iface_name, changed_props, invalidated_props)
         pass
         
     @dbus.service.method(dbus.service.INTROSPECTABLE_IFACE, in_signature='', out_signature='s',
@@ -340,29 +341,29 @@ def test():
     def get_reply_handler(expected_value):
         def handler(value):
             if value != expected_value:
-                print 'Get failed, expect %s but %s got' % (expected_value, value)
+                logging.warning('Get failed, expect %s but %s got', expected_value, value)
             else:
-                print 'Get succesful'
+                logging.debug('Get succesful')
         return handler
 
     def get_all_reply_handler(expected_dict):
         def handler(value):
             for k, v in value.iteritems():
                 if not k in expected_dict:
-                    print 'GetAll: unexpected key %s' % k
+                    logging.warning('GetAll: unexpected key %s', k)
                 elif v != expected_dict[k]:
-                    print 'GetAll: expected value of key %s is %s but %s got' % (k, expected_dict[k], v)
+                    logging.warning('GetAll: expected value of key %s is %s but %s got', k, expected_dict[k], v)
             for k in expected_dict.iterkeys():
                 if not k in value:
-                    print 'GetAll: missing key %s' % k
-            print 'GetAll finished'
+                    logging.warning('GetAll: missing key %s', k)
+            logging.debug('GetAll finished')
         return handler
 
     def set_reply_handler():
-        print 'Set succeed'
+        logging.debug('Set succeed')
 
     def error_handler(e):
-        print 'Error %s' % e
+        logging.error('Error %s', e)
 
     def introspect_reply_handler(xml):
         # print xml
@@ -370,7 +371,7 @@ def test():
 
     def msg_handler(msg):
         def handler(*args, **kwargs):
-            print msg
+            logging.debug(msg)
         return handler
 
     def test_timeout():

--- a/python/lyricsource.py
+++ b/python/lyricsource.py
@@ -343,20 +343,20 @@ def test():
 
     def search_reply(ticket, expect_status):
         if ticket in search_tickets:
-            print 'Error: search ticket %d exists' % ticket
+            logging.warning('Error: search ticket %d exists', ticket)
         else:
             search_tickets[ticket] = expect_status
 
     def search_complete_cb(ticket, status, results):
         if ticket not in search_tickets:
-            print 'Error! search ticket not exists'
+            logging.warning('Error! search ticket not exists')
             return
 
         if search_tickets[ticket] != status:
-            print 'Error! expect search %d with status %d but %d got' % \
-                (ticket, search_tickets[ticket], status)
+            logging.warning('Error! expect search %d with status %d but %d got', 
+                            ticket, search_tickets[ticket], status)
             return
-        print 'Search #%d with status %d' % (ticket, status)
+        logging.debug('Search #%d with status %d', ticket, status)
         if status == 0:
             downloadinfo = results[0]['downloadinfo']
             source.Download(downloadinfo,
@@ -367,24 +367,23 @@ def test():
 
     def download_reply(ticket, expect_status):
         if ticket in download_tickets:
-            print 'Error: download ticket %d already exists' % ticket
+            logging.warning('Error: download ticket %d already exists', ticket)
         else:
             download_tickets[ticket] = expect_status
 
     def download_complete_cb(ticket, status, content):
         if ticket not in download_tickets:
-            print 'Error! download ticket not exists'
+            logging.warning('Error! download ticket not exists')
             return
 
         if download_tickets[ticket] != status:
-            print 'Error! expect download status %d but %d got' % \
-                (download_tickets[ticket], status)
+            logging.warning('Error! expect download status %d but %d got', download_tickets[ticket], status)
             return
         if status == 0:
-            print 'Download #%d success' % ticket
-            print 'Downloaded content: \n%s' % ''.join([chr(b) for b in content])
+            logging.debug('Download #%d success', ticket)
+            logging.debug('Downloaded content: \n%s', ''.join([chr(b) for b in content]))
         else:
-            print 'Download #%d fail, msg: %s' % (ticket, ''.join([chr(b) for b in content]))
+            logging.warning('Download #%d fail, msg: %s', ticket, ''.join([chr(b) for b in content]))
         del download_tickets[ticket]
         check_quit()
 
@@ -396,7 +395,7 @@ def test():
             app.quit()
 
     def dummy_error(e):
-        print 'Error: ' + e
+        logging.warning('Error: ' + e)
 
     dummysource = DummyLyricSourcePlugin()
     app = dummysource.app


### PR DESCRIPTION
Since the Python applications are activated through dbus, whatever they
log (provided it's not filtered out) is dumped to the system logs, which
is not acceptable unless it's about actual errors.

To prevent the Python applications from flooding the system logs (quite
heavily for some of them), this commit does essentially 2 things:
- Replace all the print's (which are logged by dbus) by logging of the
  proper level
- Set the loggers to a sensible level (i.e. warning, and at least not
  debug)