### PR TITLE
Notifications: notify_notification_update would send an empty summary

### DIFF
--- a/src/ol_notify.c
+++ b/src/ol_notify.c
@@ -106,7 +106,7 @@ ol_notify_music_change (OlMetadata *info, const char *icon)
   const char *artist = ol_metadata_get_artist (info);
   if (title == NULL && artist == NULL)
     return;
-  if (title == NULL)
+  if (title == NULL || !title[0])
     title = _(UNKNOWN_TITLE);
   if (artist == NULL)
     artist = _(UNKNOWN_ARTIST);


### PR DESCRIPTION
If summary is not NULL but still an empty string, the following error is
output:

(OSD Lyrics:12344): libnotify-CRITICAL **: notify_notification_update: assertion 'summary != NULL && *summary != '\0'' failed

Enlightenment shows an empty notification when the summary is empty for
the first time, or repeats the previous notification. Now, "Unknown title"
is shown in a proper notification.