### PR TITLE
Python: make relative imports explicit in the library

### DIFF
--- a/python/app.py
+++ b/python/app.py
@@ -27,7 +27,7 @@ import dbus.service
 import glib
 import gobject
 
-from consts import DAEMON_BUS_NAME
+from .consts import DAEMON_BUS_NAME
 
 APP_BUS_PREFIX = 'org.osdlyrics.'
 

--- a/python/config.py
+++ b/python/config.py
@@ -22,7 +22,7 @@ import logging
 
 import dbus
 
-from consts import CONFIG_BUS_NAME, CONFIG_OBJECT_PATH
+from .consts import CONFIG_BUS_NAME, CONFIG_OBJECT_PATH
 
 CONFIG_INTERFACE = 'org.osdlyrics.Config'
 

--- a/python/dbusext/service.py
+++ b/python/dbusext/service.py
@@ -19,13 +19,14 @@
 #/
 
 import logging
+import xml.etree.ElementTree as xet
+
 import dbus
 import dbus.exceptions
 import dbus.service
-import xml.etree.ElementTree as xet
 import glib
 
-from property import Property
+from .property import Property
 
 
 class ObjectTypeCls(dbus.service.Object.__class__):

--- a/python/lyricsource.py
+++ b/python/lyricsource.py
@@ -23,12 +23,12 @@ import threading
 
 import dbus
 
-from app import App
-from config import Config
-from consts import (LYRIC_SOURCE_PLUGIN_INTERFACE,
-                    LYRIC_SOURCE_PLUGIN_OBJECT_PATH_PREFIX)
-from dbusext.service import Object as DBusObject, property as dbus_property
-from metadata import Metadata
+from .app import App
+from .config import Config
+from .consts import (LYRIC_SOURCE_PLUGIN_INTERFACE,
+                     LYRIC_SOURCE_PLUGIN_OBJECT_PATH_PREFIX)
+from .dbusext.service import Object as DBusObject, property as dbus_property
+from .metadata import Metadata
 
 SEARCH_SUCCEED = 0
 SEARCH_CANCELLED = 1

--- a/python/metadata.py
+++ b/python/metadata.py
@@ -23,7 +23,7 @@ import re
 
 import dbus
 
-import utils
+from . import utils
 
 class Metadata(object):
     """

--- a/python/pattern.py
+++ b/python/pattern.py
@@ -18,10 +18,11 @@
 # along with OSD Lyrics.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import urlparse
-import urllib
 import os.path
-from errors import PatternException
+import urllib
+import urlparse
+
+from .errors import PatternException
 
 def expand_file(pattern, metadata):
     """

--- a/python/player_proxy.py
+++ b/python/player_proxy.py
@@ -23,13 +23,13 @@ import logging
 import dbus
 import dbus.service
 
-from app import App
-from consts import (MPRIS2_PLAYER_INTERFACE, PLAYER_PROXY_INTERFACE,
-                    PLAYER_PROXY_OBJECT_PATH_PREFIX)
-from dbusext.service import Object as DBusObject, property as dbus_property
-import errors
-import timer
-import utils
+from .app import App
+from .consts import (MPRIS2_PLAYER_INTERFACE, PLAYER_PROXY_INTERFACE,
+                     PLAYER_PROXY_OBJECT_PATH_PREFIX)
+from .dbusext.service import Object as DBusObject, property as dbus_property
+from . import errors
+from . import timer
+from . import utils
 
 class ConnectPlayerError(errors.BaseError):
     """

--- a/python/utils.py
+++ b/python/utils.py
@@ -21,11 +21,12 @@
 import os
 import os.path
 import stat
-import urllib
-import pycurl
 import StringIO
 import sys
+import urllib
 import urlparse
+
+import pycurl
 
 __all__ = (
     'cmd_exists',


### PR DESCRIPTION
Implicit relative imports (without .) are not supported in Python 3.